### PR TITLE
Fixed incorrect peer dependency for eslint-config-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/eslint-plugin-node",
-  "version": "2.0.0",
+  "version": "2.0.1-alpha",
   "description": "Shared ESLint configuration and rules for LifeOmic projects",
   "main": "index.js",
   "repository": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "eslint-config-semistandard": "^13.0.0",
-    "eslint-config-standard": "^14.0.1",
+    "eslint-config-standard": "^12",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-lodash": "^5.1.0",
     "eslint-plugin-no-only-tests": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,10 +246,10 @@ eslint-config-semistandard@^13.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-13.0.0.tgz#52ecf19081e1b6b1ccc839d049f6429ca6252ad7"
   integrity sha512-ZuImKnf/9LeZjr6dtRJ0zEdQbjBwXu0PJR3wXJXoQeMooICMrYPyD70O1tIA9Ng+wutgLjB7UXvZOKYPvzHg+w==
 
-eslint-config-standard@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.0.1.tgz#375c3636fb4bd453cb95321d873de12e4eef790b"
-  integrity sha512-1RWsAKTDTZgA8bIM6PSC9aTGDAUlKqNkYNJlTZ5xYD/HYkIM6GlcefFvgcJ8xi0SWG5203rttKYX28zW+rKNOg==
+eslint-config-standard@^12:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
+  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Depends on v12, not v14.